### PR TITLE
Feat: Replace legacy SHA-pin checks with gha-workflow-linter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,7 @@ indent_size = 2
 max_line_length = 80
 
 [*.py]
-max_line_legth = 120
+max_line_length = 120
 
 [*.sh]
 max_line_length = 80

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -20,18 +20,23 @@ jobs:
   tests:
     name: "Test local GitHub Action"
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
       - name: 'Checkout repository'
+        # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # Initial test of local repository (testing.yaml)
+      # Initial test of local repository (this repo's own workflows)
       - name: "Running local action: ${{ github.repository }}"
         uses: ./
+        with:
+          no_checkout: true
 
       # Perform setup prior to running test(s)
       - name: 'Checkout sample project repository'
+        # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "lfreleng-actions/test-python-project"
@@ -52,6 +57,7 @@ jobs:
         continue-on-error: true
         with:
           path_prefix: "/tmp/invalid-path"
+          no_checkout: true
 
       # Failure testing is also important
       - name: "Error if step above did NOT fail"

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -27,29 +27,41 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
-      # Initial test of local repository (this repo's own workflows)
+      # Test 1: default behaviour (pull_request -> changed-files only;
+      # other events -> full scan)
       - name: "Running local action: ${{ github.repository }}"
         uses: ./
         with:
           no_checkout: true
 
-      # Perform setup prior to running test(s)
+      # Test 2: force a full scan irrespective of event
+      - name: "Running local action: ${{ github.repository }} [full_scan]"
+        uses: ./
+        with:
+          no_checkout: true
+          full_scan: 'true'
+
+      # Test 3: scan a sample external project
       - name: 'Checkout sample project repository'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "lfreleng-actions/test-python-project"
           path: 'test-python-project'
+          fetch-depth: 0
 
-      # Test downloaded sample Python project
       # yamllint disable-line rule:line-length
       - name: "Running local action: ${{ github.repository }} [test-python-project]"
         uses: ./
         with:
           path_prefix: 'test-python-project'
           no_checkout: true
+          full_scan: 'true'
 
+      # Test 4: invalid path_prefix should fail
       # yamllint disable-line rule:line-length
       - name: "Running local action: ${{ github.repository }} [Override Failure]"
         uses: ./
@@ -59,7 +71,6 @@ jobs:
           path_prefix: "/tmp/invalid-path"
           no_checkout: true
 
-      # Failure testing is also important
       - name: "Error if step above did NOT fail"
         if: steps.failure.outcome == 'success'
         shell: bash

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -19,7 +19,7 @@ jobs:
   ### Test the GitHub Action in this Repository ###
   tests:
     name: "Test local GitHub Action"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -23,12 +23,16 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      # Needed on pull_request events: the composite action invokes
+      # repository-metadata-action to list PR-changed files.
+      pull-requests: read
     steps:
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       # Test 1: default behaviour (pull_request -> changed-files only;
       # other events -> full scan)
@@ -61,6 +65,7 @@ jobs:
           repository: "lfreleng-actions/test-python-project"
           path: 'test-python-project'
           fetch-depth: 0
+          persist-credentials: false
 
       # yamllint disable-line rule:line-length
       - name: "Running local action: ${{ github.repository }} [test-python-project]"

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -44,6 +44,15 @@ jobs:
           no_checkout: true
           full_scan: 'true'
 
+      # Test 2b: full scan with a pinned linter_version
+      # yamllint disable-line rule:line-length
+      - name: "Running local action: ${{ github.repository }} [pinned linter_version]"
+        uses: ./
+        with:
+          no_checkout: true
+          full_scan: 'true'
+          linter_version: '1.0.2'
+
       # Test 3: scan a sample external project
       - name: 'Checkout sample project repository'
         # yamllint disable-line rule:line-length

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,16 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 ci:
-  autofix_commit_msg: "Chore: pre-commit autoupdate"
-  autoupdate_commit_msg: "Chore: pre-commit autoupdate"
+  # pre-commit.ci sandbox prevents network calls; disable gha-workflow-linter
+  skip: [gha-workflow-linter]
+  autofix_commit_msg: |
+    Chore: pre-commit autofixes
+
+    Signed-off-by: pre-commit-ci[bot] <pre-commit-ci@users.noreply.github.com>
+  autoupdate_commit_msg: |
+    Chore: pre-commit autoupdate
+
+    Signed-off-by: pre-commit-ci[bot] <pre-commit-ci@users.noreply.github.com>
 
 exclude: "^docs/conf.py"
 
@@ -91,3 +99,29 @@ repos:
     rev: 2ccb47ff45ad361a21071a7eedda4c37e6ae8c5a  # frozen: v2.4.2
     hooks:
       - id: codespell
+
+  # Requires a mirror, primary repo lacks .pre-commit-hooks.yaml
+  - repo: https://github.com/DetachHead/basedpyright-prek-mirror
+    rev: 2de179c8dd041d4caa777c4d97fecdb97a572e8d  # frozen: 1.39.2
+    hooks:
+      - id: basedpyright
+
+  - repo: https://github.com/lfreleng-actions/gha-workflow-linter
+    rev: a7caf8f3a1a05688d1cee46615ff94def617e5a3  # frozen: v1.0.2
+    hooks:
+      - id: gha-workflow-linter
+
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: ed81924a8b1cecdaa570b072528fa80c9c4d6ccd  # frozen: 0.37.1
+    hooks:
+      - id: check-github-actions
+      - id: check-github-workflows
+      - id: check-jsonschema
+        name: Check GitHub Workflows set timeout-minutes
+        args:
+          - --builtin-schema
+          - github-workflows-require-timeout
+        files: ^\.github/workflows/[^/]+$
+        types:
+          - yaml
+      - id: check-readthedocs

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ on:
 ```yaml
 jobs:
   check-actions:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:

--- a/README.md
+++ b/README.md
@@ -53,47 +53,61 @@ jobs:
 
 <!-- markdownlint-disable MD013 -->
 
-| Variable Name | Required | Default                         | Description                                      |
-| ------------- | -------- | ------------------------------- | ------------------------------------------------ |
-| path_prefix   | False    | '.' (current working directory) | Directory location containing project code       |
-| no_checkout   | False    | false                           | Don't perform a checkout of the local repository |
+| Variable Name | Required | Default                         | Description                                              |
+| ------------- | -------- | ------------------------------- | -------------------------------------------------------- |
+| path_prefix   | False    | '.' (current working directory) | Directory location containing project code               |
+| no_checkout   | False    | false                           | Don't perform a checkout of the local repository         |
+| full_scan     | False    | false                           | Force a full repository scan, even on `pull_request`     |
 
 <!-- markdownlint-enable MD013 -->
 
 ## Behaviour
 
-The action:
+### Pull Requests
 
-1. Checks out the repository (or the pull request HEAD).
-2. Installs [`uv`][uvx] via `astral-sh/setup-uv`.
-3. Invokes `gha-workflow-linter lint` against `path_prefix` using `uvx`,
-   which downloads and runs the latest published release on demand.
+When triggered against a `pull_request` event, the action:
 
-By default `gha-workflow-linter` enforces SHA pinning for all action and
-workflow calls; the action fails if any reference uses a tag, branch, or
-unpinned value, or if a referenced repository or commit cannot be resolved.
+1. Checks out the PR head (with full history).
+2. Calls [`repository-metadata-action`][rma] to obtain the list of files
+   changed in the pull request. All summary outputs and artifact uploads
+   from that action are suppressed (`github_summary`, `gerrit_summary`,
+   `files_summary`, and `artifact_upload` all set to `false`) so that
+   workflows already invoking that action elsewhere do not see duplicated
+   `GITHUB_STEP_SUMMARY` content.
+3. Filters the changed-files list to YAML files under
+   `<path_prefix>/.github/` (workflows under `.github/workflows/` and
+   composite-action `action.yaml` files under `.github/actions/`).
+4. Invokes `gha-workflow-linter lint` with one `--files` argument per
+   matched file, validating only those.
+
+If the change does not touch any workflow or composite-action YAML, the
+linter step is skipped and the action exits successfully. Set the
+`full_scan` input to `true` to force a full-tree scan even on pull
+requests.
+
+[rma]: https://github.com/lfreleng-actions/repository-metadata-action
+
+### Manual / push / scheduled invocation
+
+For any non-`pull_request` event (or when `full_scan: 'true'`), the
+action runs `gha-workflow-linter lint <path_prefix>` against the entire
+workflow tree.
+
+### Auto-fix
+
+The linter's auto-fix mode is **disabled** when run from this action
+(`--no-auto-fix`). Rewrites in an ephemeral CI runner are discarded and
+silently mask validation errors. Run `gha-workflow-linter lint
+--auto-fix` locally to migrate a repository, then commit the result.
 
 The action passes `GITHUB_TOKEN` (the workflow's GitHub token) to the
 linter so that GraphQL API calls authenticate and avoid rate limits.
-
-### Pull Requests
-
-When triggered against a pull request, the action checks out the PR head
-and lints the workflows present in the change. The linter scans the entire
-repository's workflow tree; this differs from earlier versions of the
-action which only scanned the diff. Repositories that already use SHA
-pinning across the tree see no change in behaviour; repositories that do
-not should run the linter once with `--auto-fix` locally to migrate.
-
-### Manual Invocation
-
-When invoked via `workflow_dispatch` the action checks out and lints the
-default branch state.
 
 ## Implementation Details
 
 The previous implementation combined `tj-actions/changed-files` with
 `zgosalvez/github-actions-ensure-sha-pinned-actions`. This release
-replaces both with `gha-workflow-linter`, which provides SHA pinning
-enforcement, repository/reference validation, caching and auto-fix
-support in a single tool maintained alongside this action.
+replaces both with `gha-workflow-linter` (and uses our own
+`repository-metadata-action` to scope pull-request runs), providing
+SHA pinning enforcement, repository/reference validation, caching and
+auto-fix support in a single tool maintained alongside this action.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ Verifies action/workflow calls use SHA commit values.
 
 ## pinned-versions-action
 
+This action wraps [`gha-workflow-linter`][gwl], a Python CLI tool from the
+Linux Foundation Release Engineering team. It validates that GitHub Actions
+workflow and action calls in the repository pin to immutable commit SHAs,
+and that the referenced repositories, tags, branches and commits exist.
+
+The CLI is fetched and run via [`uvx`][uvx] (`astral-sh/setup-uv`), so no
+local Python environment setup is required.
+
+[gwl]: https://github.com/lfreleng-actions/gha-workflow-linter
+[uvx]: https://docs.astral.sh/uv/guides/tools/
+
 ## Recommended Event Triggers
 
 ```yaml
@@ -51,15 +62,38 @@ jobs:
 
 ## Behaviour
 
+The action:
+
+1. Checks out the repository (or the pull request HEAD).
+2. Installs [`uv`][uvx] via `astral-sh/setup-uv`.
+3. Invokes `gha-workflow-linter lint` against `path_prefix` using `uvx`,
+   which downloads and runs the latest published release on demand.
+
+By default `gha-workflow-linter` enforces SHA pinning for all action and
+workflow calls; the action fails if any reference uses a tag, branch, or
+unpinned value, or if a referenced repository or commit cannot be resolved.
+
+The action passes `GITHUB_TOKEN` (the workflow's GitHub token) to the
+linter so that GraphQL API calls authenticate and avoid rate limits.
+
 ### Pull Requests
 
-When triggered against a pull request, will audit the change content for any
-calls to GitHub actions/workflows that are not pinned to a SHA commit value.
-This scans files changed in the pull request, and will NOT block merges
-where GitHub actions elsewhere in the repository do not use SHA/commit values.
+When triggered against a pull request, the action checks out the PR head
+and lints the workflows present in the change. The linter scans the entire
+repository's workflow tree; this differs from earlier versions of the
+action which only scanned the diff. Repositories that already use SHA
+pinning across the tree see no change in behaviour; repositories that do
+not should run the linter once with `--auto-fix` locally to migrate.
 
 ### Manual Invocation
 
-Operates differently when explicitly called using "workflow_dispatch" trigger.
-Will scan the entire repository for action/workflow calls and report results
-for all GitHub actions/workflows found.
+When invoked via `workflow_dispatch` the action checks out and lints the
+default branch state.
+
+## Implementation Details
+
+The previous implementation combined `tj-actions/changed-files` with
+`zgosalvez/github-actions-ensure-sha-pinned-actions`. This release
+replaces both with `gha-workflow-linter`, which provides SHA pinning
+enforcement, repository/reference validation, caching and auto-fix
+support in a single tool maintained alongside this action.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,25 @@ jobs:
 | path_prefix   | False    | '.' (current working directory) | Directory location containing project code               |
 | no_checkout   | False    | false                           | Don't perform a checkout of the local repository         |
 | full_scan     | False    | false                           | Force a full repository scan, even on `pull_request`     |
+| linter_version| False    | (latest)                        | Pin `gha-workflow-linter` to a specific PyPI version     |
 
 <!-- markdownlint-enable MD013 -->
+
+### Pinning the linter version
+
+By default the action runs the **latest** released `gha-workflow-linter`
+from PyPI on each invocation. To pin a specific version (and avoid
+non-deterministic behaviour across runs), set `linter_version`:
+
+```yaml
+- name: 'Check Pinned Versions'
+  uses: lfreleng-actions/pinned-versions-action@main
+  with:
+    linter_version: '1.0.2'
+```
+
+When set, the action invokes
+`uvx --from gha-workflow-linter==<version> ...`.
 
 ## Behaviour
 

--- a/README.md
+++ b/README.md
@@ -42,12 +42,27 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # pull-requests: read lets the metadata step list PR-changed
+      # files on pull_request events. Safe to grant unconditionally;
+      # ignored on other events.
+      pull-requests: read
     steps:
       - name: 'Check Pinned Versions'
-        uses: lfreleng-actions/pinned-versions-action@main
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/pinned-versions-action@38f4a2758d6314213f744dba3f0d68335e5562bf # v0.1.2
 ```
 
 <!-- markdownlint-enable MD013 -->
+
+### Required permissions
+
+The action needs the following permissions on `GITHUB_TOKEN`:
+
+- `contents: read` — to check out the repository.
+- `pull-requests: read` — needed on `pull_request` events so the
+  embedded `repository-metadata-action` can list the files that the
+  pull request changes. Without this permission, PR-scoped runs fail
+  in the metadata step.
 
 ## Inputs
 
@@ -68,12 +83,17 @@ By default the action runs the **latest** released `gha-workflow-linter`
 from PyPI on each invocation. To pin a specific version (and avoid
 non-deterministic behaviour across runs), set `linter_version`:
 
+<!-- markdownlint-disable MD013 -->
+
 ```yaml
 - name: 'Check Pinned Versions'
-  uses: lfreleng-actions/pinned-versions-action@main
+  # yamllint disable-line rule:line-length
+  uses: lfreleng-actions/pinned-versions-action@38f4a2758d6314213f744dba3f0d68335e5562bf # v0.1.2
   with:
     linter_version: '1.0.2'
 ```
+
+<!-- markdownlint-enable MD013 -->
 
 When set, the action invokes
 `uvx --from gha-workflow-linter==<version> ...`.
@@ -84,16 +104,19 @@ When set, the action invokes
 
 When triggered against a `pull_request` event, the action:
 
-1. Checks out the PR head (with full history).
+1. Checks out the PR head (default shallow checkout).
 2. Calls [`repository-metadata-action`][rma] to fetch the list of files
    that the pull request changes. The action sets all summary outputs
    and artifact uploads from that action to `false` (`github_summary`,
    `gerrit_summary`, `files_summary`, and `artifact_upload`) so that
    workflows already invoking that action elsewhere do not see duplicate
    `GITHUB_STEP_SUMMARY` content.
-3. Filters the changed-files list to YAML files under
-   `<path_prefix>/.github/` (workflows under `.github/workflows/` and
-   composite-action `action.yaml` files under `.github/actions/`).
+3. Restricts the changed-files list to workflow / composite-action
+   definitions: any `*.yml` or `*.yaml` under
+   `<path_prefix>/.github/workflows/`, plus `action.yml` / `action.yaml`
+   files under `<path_prefix>/.github/actions/`. Other YAML under
+   `.github/` (for example `dependabot.yml` or `actionlint.yaml`) falls
+   outside this scope and the action ignores it.
 4. Invokes `gha-workflow-linter lint` with one `--files` argument per
    matched file, validating that subset of files.
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Linux Foundation Release Engineering team. It validates that GitHub Actions
 workflow and action calls in the repository pin to immutable commit SHAs,
 and that the referenced repositories, tags, branches and commits exist.
 
-The CLI is fetched and run via [`uvx`][uvx] (`astral-sh/setup-uv`), so no
-local Python environment setup is required.
+The action installs and runs the CLI via [`uvx`][uvx]
+(`astral-sh/setup-uv`), so callers need no local Python environment.
 
 [gwl]: https://github.com/lfreleng-actions/gha-workflow-linter
 [uvx]: https://docs.astral.sh/uv/guides/tools/
@@ -85,22 +85,21 @@ When set, the action invokes
 When triggered against a `pull_request` event, the action:
 
 1. Checks out the PR head (with full history).
-2. Calls [`repository-metadata-action`][rma] to obtain the list of files
-   changed in the pull request. All summary outputs and artifact uploads
-   from that action are suppressed (`github_summary`, `gerrit_summary`,
-   `files_summary`, and `artifact_upload` all set to `false`) so that
-   workflows already invoking that action elsewhere do not see duplicated
+2. Calls [`repository-metadata-action`][rma] to fetch the list of files
+   that the pull request changes. The action sets all summary outputs
+   and artifact uploads from that action to `false` (`github_summary`,
+   `gerrit_summary`, `files_summary`, and `artifact_upload`) so that
+   workflows already invoking that action elsewhere do not see duplicate
    `GITHUB_STEP_SUMMARY` content.
 3. Filters the changed-files list to YAML files under
    `<path_prefix>/.github/` (workflows under `.github/workflows/` and
    composite-action `action.yaml` files under `.github/actions/`).
 4. Invokes `gha-workflow-linter lint` with one `--files` argument per
-   matched file, validating only those.
+   matched file, validating that subset of files.
 
-If the change does not touch any workflow or composite-action YAML, the
-linter step is skipped and the action exits successfully. Set the
-`full_scan` input to `true` to force a full-tree scan even on pull
-requests.
+If the change touches no workflow or composite-action YAML, the action
+skips the linter step and exits with success. Set the `full_scan` input
+to `true` to force a full-tree scan even on pull requests.
 
 [rma]: https://github.com/lfreleng-actions/repository-metadata-action
 
@@ -112,10 +111,11 @@ workflow tree.
 
 ### Auto-fix
 
-The linter's auto-fix mode is **disabled** when run from this action
-(`--no-auto-fix`). Rewrites in an ephemeral CI runner are discarded and
-silently mask validation errors. Run `gha-workflow-linter lint
---auto-fix` locally to migrate a repository, then commit the result.
+The action **disables** the linter's auto-fix mode (`--no-auto-fix`).
+Ephemeral CI runners throw away any rewrites the linter makes, which
+hides validation errors from the workflow log. Run `gha-workflow-linter
+lint --auto-fix` locally to migrate a repository, then commit the
+result.
 
 The action passes `GITHUB_TOKEN` (the workflow's GitHub token) to the
 linter so that GraphQL API calls authenticate and avoid rate limits.

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ jobs:
 
 <!-- markdownlint-disable MD013 -->
 
-| Variable Name | Required | Default                         | Description                                              |
-| ------------- | -------- | ------------------------------- | -------------------------------------------------------- |
-| path_prefix   | False    | '.' (current working directory) | Directory location containing project code               |
-| no_checkout   | False    | false                           | Don't perform a checkout of the local repository         |
-| full_scan     | False    | false                           | Force a full repository scan, even on `pull_request`     |
-| linter_version| False    | (latest)                        | Pin `gha-workflow-linter` to a specific PyPI version     |
+| Variable Name  | Required | Default                         | Description                                          |
+| -------------- | -------- | ------------------------------- | ---------------------------------------------------- |
+| path_prefix    | False    | '.' (current working directory) | Directory location containing project code           |
+| no_checkout    | False    | false                           | Don't perform a checkout of the local repository     |
+| full_scan      | False    | false                           | Force a full repository scan, even on `pull_request` |
+| linter_version | False    | (latest)                        | Pin `gha-workflow-linter` to a specific PyPI version |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/action.yaml
+++ b/action.yaml
@@ -14,7 +14,7 @@ inputs:
   no_checkout:
     description: 'Do not checkout local repository; used for testing'
     required: false
-    default: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -22,28 +22,9 @@ runs:
     # Checkout repository on manual invocation
     - name: 'Checkout repository'
       # yamllint disable-line rule:line-length
-      if: github.event_name == 'workflow_dispatch'
+      if: github.event_name == 'workflow_dispatch' && inputs.no_checkout != 'true'
       # yamllint disable-line rule:line-length
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-    - name: 'Check path_prefix directory'
-      if: inputs.path_prefix != '.'
-      shell: bash
-      run: |
-        if [ ! -d "${{ inputs.path_prefix }}" ]; then
-          echo 'Error: path_prefix is not a valid directory ❌'
-          echo "${{ inputs.path_prefix }}"
-          exit 1
-        fi
-
-    # Scan all GitHub actions/workflows on manual invocation
-    - name: 'Audit all GitHub actions/workflows'
-      if: github.event_name == 'workflow_dispatch'
-      shell: bash
-      run: |
-        # Audit all GitHub actions/workflows
-        echo 'workflow_changes=true' >> "$GITHUB_ENV"
-        echo 'Auditing all actions/workflows ✅'
 
     # Checkout change when invoked on a pull request
     - name: 'Checkout pull request'
@@ -54,52 +35,29 @@ runs:
       with:
         ref: "${{ github.event.pull_request.head.sha }}"
 
-    # Get files changed in the pull request from upstream action
-    - name: 'Get changed files from action'
-      id: changed-files
-      if: github.event_name != 'workflow_dispatch'
-      # yamllint disable-line rule:line-length
-      uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
-      with:
-        since_last_remote_commit: true
-        files: |
-          .github/**/*.{yml,yaml}
-
-    - name: 'Prune unmodified workflows/actions from scope'
-      if: github.event_name != 'workflow_dispatch'
-      env:
-        # yamllint disable-line rule:line-length
-        all_changed_files: "${{ steps.changed-files.outputs.all_changed_files }}"
+    - name: 'Check path_prefix directory'
+      if: inputs.path_prefix != '.'
       shell: bash
       run: |
-        # ✂️ Prune unmodified workflows/actions from scope
-        find ${{ inputs.path_prefix }}/.github -type f \
-          -name '*.yaml' -o -name '*.yml' > github.txt
-        for yamlfile in ${all_changed_files}; do
-          echo "$yamlfile" >> changed.txt
-        done
-        if [ ! -f 'changed.txt' ]; then
-          echo 'No changes in scope for check ⏩'
-          echo 'workflow_changes=false' >> "$GITHUB_ENV"
-        else
-          # grep exits 1 when no unmodified files remain (all files changed);
-          # use || to capture status before set -e can trigger on exit code 1
-          status=0
-          grep -Fvf changed.txt github.txt > unmodified.txt || status=$?
-          if [ "$status" -ne 0 ] && [ "$status" -ne 1 ]; then
-            echo "Error: grep failed with exit code $status" >&2
-            exit "$status"
-          fi
-          while IFS= read -r yamlfile
-          do
-            rm "$yamlfile"
-          done < unmodified.txt
-          echo 'workflow_changes=true' >> "$GITHUB_ENV"
-          echo 'Files found to check ✅'
-          cat changed.txt
+        # Validate path_prefix
+        if [ ! -d "${{ inputs.path_prefix }}" ]; then
+          echo 'Error: path_prefix is not a valid directory ❌'
+          echo "${{ inputs.path_prefix }}"
+          exit 1
         fi
 
-    - name: 'Ensure SHA pinned actions'
+    - name: 'Setup uv'
       # yamllint disable-line rule:line-length
-      uses: zgosalvez/github-actions-ensure-sha-pinned-actions@ca46236c6ce584ae24bc6283ba8dcf4b3ec8a066 # v5.0.4
-      if: env.workflow_changes == 'true'
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        enable-cache: true
+
+    - name: 'Run gha-workflow-linter'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        # Run gha-workflow-linter via uvx (requires SHA pinning by default)
+        echo "Running gha-workflow-linter against: ${{ inputs.path_prefix }}"
+        uvx --from gha-workflow-linter gha-workflow-linter lint \
+          "${{ inputs.path_prefix }}"

--- a/action.yaml
+++ b/action.yaml
@@ -39,8 +39,9 @@ runs:
       # yamllint disable-line rule:line-length
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        # Need history so repository-metadata-action's git fallback works
-        fetch-depth: 0
+        # Read-only checkout: the action only inspects working-tree files,
+        # so a shallow checkout suffices and credentials need not persist.
+        persist-credentials: false
 
     # Checkout change when invoked on a pull request
     - name: 'Checkout pull request'
@@ -50,7 +51,8 @@ runs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: "${{ github.event.pull_request.head.sha }}"
-        fetch-depth: 0
+        # Read-only checkout: shallow + no persisted credentials.
+        persist-credentials: false
 
     - name: 'Check path_prefix directory'
       if: inputs.path_prefix != '.'
@@ -62,28 +64,6 @@ runs:
           echo "${{ inputs.path_prefix }}"
           exit 1
         fi
-
-    - name: 'Setup uv'
-      # yamllint disable-line rule:line-length
-      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-      with:
-        enable-cache: true
-
-    - name: 'Resolve gha-workflow-linter version'
-      id: resolve_version
-      shell: bash
-      env:
-        LINTER_VERSION: ${{ inputs.linter_version }}
-      run: |
-        # Build the uvx '--from' specifier; pin to a version when supplied
-        if [ -n "$LINTER_VERSION" ]; then
-          spec="gha-workflow-linter==${LINTER_VERSION}"
-          echo "Pinning gha-workflow-linter to version: ${LINTER_VERSION}"
-        else
-          spec="gha-workflow-linter"
-          echo "Using latest released gha-workflow-linter from PyPI"
-        fi
-        echo "uvx_from=${spec}" >> "$GITHUB_OUTPUT"
 
     # ------------------------------------------------------------------
     # Pull request: gather changed workflow/action YAML files via
@@ -114,41 +94,109 @@ runs:
         CHANGED_FILES: ${{ steps.metadata.outputs.changed_files }}
         PATH_PREFIX: ${{ inputs.path_prefix }}
       run: |
-        # Filter changed files to YAML under .github (rel to path_prefix)
-        prefix="${PATH_PREFIX%/}"
+        # Filter changed files to YAML under .github (rel to path_prefix).
+        # Normalise the prefix so common relative variants ('./sub', 'sub/')
+        # match the unprefixed paths emitted by repository-metadata-action.
+        prefix="${PATH_PREFIX#./}"
+        prefix="${prefix%/}"
         if [ "$prefix" = "." ] || [ -z "$prefix" ]; then
           gh_dir=".github"
         else
           gh_dir="${prefix}/.github"
         fi
 
-        : > matched.txt
+        # Write the matched-files list under RUNNER_TEMP so we never clash
+        # with files in the caller repository's workspace.
+        matched_file="${RUNNER_TEMP:-/tmp}/pinned-versions-matched.txt"
+        : > "$matched_file"
+        # Restrict the match to actual workflow/composite-action definitions
+        # (anything else under .github/ — such as dependabot.yml or
+        # actionlint.yaml — is not in scope for SHA-pin / call-target
+        # validation and may not even be valid GHA YAML).
+        workflows_dir="${gh_dir}/workflows"
+        actions_dir="${gh_dir}/actions"
+
         # changed_files from repository-metadata-action is newline-separated
         while IFS= read -r f; do
           [ -z "$f" ] && continue
-          # Match any *.yml or *.yaml under <gh_dir>/ (recursive)
-          if [ "${f#"${gh_dir}/"}" != "$f" ]; then
+          match=false
+          # Workflow files: any *.yml/*.yaml directly under .github/workflows/
+          # (GitHub does not recurse, but we accept nested paths defensively).
+          if [ "${f#"${workflows_dir}/"}" != "$f" ]; then
             case "$f" in
-              *.yml|*.yaml)
-                # Confirm the file still exists in the checkout (renames /
-                # deletions may otherwise drop out)
-                if [ -f "$f" ]; then
-                  echo "$f" >> matched.txt
-                fi
-                ;;
+              *.yml|*.yaml) match=true ;;
             esac
+          fi
+          # Composite actions: action.yml / action.yaml under
+          # .github/actions/, including the root-level case
+          # (.github/actions/action.yml without an intermediate dir).
+          if [ "$match" = false ] \
+            && [ "${f#"${actions_dir}/"}" != "$f" ]; then
+            case "${f#"${actions_dir}/"}" in
+              action.yml|action.yaml|*/action.yml|*/action.yaml)
+                match=true ;;
+            esac
+          fi
+          if [ "$match" = true ]; then
+            # Confirm the file still exists in the checkout (renames /
+            # deletions may otherwise drop out)
+            if [ -f "$f" ]; then
+              echo "$f" >> "$matched_file"
+            fi
           fi
         done <<< "$CHANGED_FILES"
 
-        if [ -s matched.txt ]; then
-          count=$(wc -l < matched.txt | tr -d ' ')
+        if [ -s "$matched_file" ]; then
+          count=$(wc -l < "$matched_file" | tr -d ' ')
           echo "Found $count changed workflow/action file(s) to lint:"
-          sed 's/^/  - /' matched.txt
+          sed 's/^/  - /' "$matched_file"
           echo "have_changes=true" >> "$GITHUB_OUTPUT"
+          echo "matched_file=${matched_file}" >> "$GITHUB_OUTPUT"
         else
           echo 'No workflow/action changes in scope for check ⏩'
           echo "have_changes=false" >> "$GITHUB_OUTPUT"
         fi
+
+    # ------------------------------------------------------------------
+    # Install uv and resolve the linter version only when we know the
+    # linter will actually run. On pull_request events that touch no
+    # workflow/action YAML, this avoids an unnecessary uv install and
+    # PyPI fetch.
+    # ------------------------------------------------------------------
+    - name: 'Setup uv'
+      # yamllint disable-line rule:line-length
+      if: github.event_name != 'pull_request' || inputs.full_scan == 'true' || steps.filter.outputs.have_changes == 'true'
+      # yamllint disable-line rule:line-length
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        enable-cache: true
+
+    - name: 'Resolve gha-workflow-linter version'
+      id: resolve_version
+      # yamllint disable-line rule:line-length
+      if: github.event_name != 'pull_request' || inputs.full_scan == 'true' || steps.filter.outputs.have_changes == 'true'
+      shell: bash
+      env:
+        LINTER_VERSION: ${{ inputs.linter_version }}
+      run: |
+        # Build the uvx '--from' specifier; pin to a version when supplied.
+        # Validate the user-supplied value against a conservative pattern
+        # before writing it to GITHUB_OUTPUT to avoid workflow command
+        # injection (e.g. embedded newlines).
+        if [ -n "$LINTER_VERSION" ]; then
+          if ! printf '%s' "$LINTER_VERSION" | \
+            grep -Eq '^[A-Za-z0-9][A-Za-z0-9._+-]*$'; then
+            echo "Error: linter_version contains invalid characters ❌"
+            echo "Provided value: ${LINTER_VERSION}"
+            exit 1
+          fi
+          spec="gha-workflow-linter==${LINTER_VERSION}"
+          echo "Pinning gha-workflow-linter to version: ${LINTER_VERSION}"
+        else
+          spec="gha-workflow-linter"
+          echo "Using latest released gha-workflow-linter from PyPI"
+        fi
+        echo "uvx_from=${spec}" >> "$GITHUB_OUTPUT"
 
     - name: 'Run gha-workflow-linter (pull request changed files)'
       # yamllint disable-line rule:line-length
@@ -163,7 +211,7 @@ runs:
         while IFS= read -r f; do
           [ -z "$f" ] && continue
           args+=(--files "$f")
-        done < matched.txt
+        done < "${{ steps.filter.outputs.matched_file }}"
 
         echo "Running gha-workflow-linter on changed files only"
         uvx --from "${{ steps.resolve_version.outputs.uvx_from }}" \

--- a/action.yaml
+++ b/action.yaml
@@ -15,25 +15,35 @@ inputs:
     description: 'Do not checkout local repository; used for testing'
     required: false
     default: 'false'
+  full_scan:
+    description: >-
+      Force a full repository scan even on pull_request events
+      (default: pull_request events scan only changed workflow files)
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
   steps:
-    # Checkout repository on manual invocation
+    # Checkout repository on manual invocation (or any non-PR event)
     - name: 'Checkout repository'
       # yamllint disable-line rule:line-length
-      if: github.event_name == 'workflow_dispatch' && inputs.no_checkout != 'true'
+      if: github.event_name != 'pull_request' && inputs.no_checkout != 'true'
       # yamllint disable-line rule:line-length
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        # Need history so repository-metadata-action's git fallback works
+        fetch-depth: 0
 
     # Checkout change when invoked on a pull request
     - name: 'Checkout pull request'
       # yamllint disable-line rule:line-length
-      if: github.event_name != 'workflow_dispatch' && inputs.no_checkout != 'true'
+      if: github.event_name == 'pull_request' && inputs.no_checkout != 'true'
       # yamllint disable-line rule:line-length
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: "${{ github.event.pull_request.head.sha }}"
+        fetch-depth: 0
 
     - name: 'Check path_prefix directory'
       if: inputs.path_prefix != '.'
@@ -52,12 +62,103 @@ runs:
       with:
         enable-cache: true
 
-    - name: 'Run gha-workflow-linter'
+    # ------------------------------------------------------------------
+    # Pull request: gather changed workflow/action YAML files via
+    # repository-metadata-action and lint only those. All step-summary
+    # output and artifact uploads from that action are suppressed; other
+    # actions/workflows in the same job typically already render that
+    # summary content, so we deliberately avoid duplicating it here.
+    # ------------------------------------------------------------------
+    - name: 'Repository metadata (pull request changed files)'
+      id: metadata
+      # yamllint disable-line rule:line-length
+      if: github.event_name == 'pull_request' && inputs.full_scan != 'true'
+      # yamllint disable-line rule:line-length
+      uses: lfreleng-actions/repository-metadata-action@ceabcd987d13d7bfefd2372e01eebb0ddac45956 # v0.2.0
+      with:
+        github_token: ${{ github.token }}
+        github_summary: 'false'
+        gerrit_summary: 'false'
+        files_summary: 'false'
+        artifact_upload: 'false'
+
+    - name: 'Filter changed workflow/action files'
+      id: filter
+      # yamllint disable-line rule:line-length
+      if: github.event_name == 'pull_request' && inputs.full_scan != 'true'
+      shell: bash
+      env:
+        CHANGED_FILES: ${{ steps.metadata.outputs.changed_files }}
+        PATH_PREFIX: ${{ inputs.path_prefix }}
+      run: |
+        # Filter changed files to YAML under .github (rel to path_prefix)
+        prefix="${PATH_PREFIX%/}"
+        if [ "$prefix" = "." ] || [ -z "$prefix" ]; then
+          gh_dir=".github"
+        else
+          gh_dir="${prefix}/.github"
+        fi
+
+        : > matched.txt
+        # changed_files from repository-metadata-action is newline-separated
+        while IFS= read -r f; do
+          [ -z "$f" ] && continue
+          # Match any *.yml or *.yaml under <gh_dir>/ (recursive)
+          if [ "${f#"${gh_dir}/"}" != "$f" ]; then
+            case "$f" in
+              *.yml|*.yaml)
+                # Confirm the file still exists in the checkout (renames /
+                # deletions may otherwise drop out)
+                if [ -f "$f" ]; then
+                  echo "$f" >> matched.txt
+                fi
+                ;;
+            esac
+          fi
+        done <<< "$CHANGED_FILES"
+
+        if [ -s matched.txt ]; then
+          count=$(wc -l < matched.txt | tr -d ' ')
+          echo "Found $count changed workflow/action file(s) to lint:"
+          sed 's/^/  - /' matched.txt
+          echo "have_changes=true" >> "$GITHUB_OUTPUT"
+        else
+          echo 'No workflow/action changes in scope for check ⏩'
+          echo "have_changes=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: 'Run gha-workflow-linter (pull request changed files)'
+      # yamllint disable-line rule:line-length
+      if: github.event_name == 'pull_request' && inputs.full_scan != 'true' && steps.filter.outputs.have_changes == 'true'
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
-        # Run gha-workflow-linter via uvx (requires SHA pinning by default)
+        # Lint only the changed workflow/action files (no auto-fix in CI:
+        # rewrites in ephemeral runners are pointless and would mask errors)
+        args=(--no-auto-fix)
+        while IFS= read -r f; do
+          [ -z "$f" ] && continue
+          args+=(--files "$f")
+        done < matched.txt
+
+        echo "Running gha-workflow-linter on changed files only"
+        uvx --from gha-workflow-linter gha-workflow-linter lint \
+          "${args[@]}"
+
+    # ------------------------------------------------------------------
+    # Full scan: workflow_dispatch, push, schedule, full_scan=true, etc.
+    # ------------------------------------------------------------------
+    - name: 'Run gha-workflow-linter (full scan)'
+      # yamllint disable-line rule:line-length
+      if: github.event_name != 'pull_request' || inputs.full_scan == 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        # Run gha-workflow-linter against the full path_prefix
+        # (no auto-fix: see note in PR-changed-files step above)
         echo "Running gha-workflow-linter against: ${{ inputs.path_prefix }}"
         uvx --from gha-workflow-linter gha-workflow-linter lint \
+          --no-auto-fix \
           "${{ inputs.path_prefix }}"

--- a/action.yaml
+++ b/action.yaml
@@ -21,6 +21,13 @@ inputs:
       (default: pull_request events scan only changed workflow files)
     required: false
     default: 'false'
+  linter_version:
+    description: >-
+      Optional gha-workflow-linter version to install from PyPI
+      (e.g. '1.0.2'). When unset, uvx fetches the latest released
+      version on each run.
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -61,6 +68,22 @@ runs:
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         enable-cache: true
+
+    - name: 'Resolve gha-workflow-linter version'
+      id: resolve_version
+      shell: bash
+      env:
+        LINTER_VERSION: ${{ inputs.linter_version }}
+      run: |
+        # Build the uvx '--from' specifier; pin to a version when supplied
+        if [ -n "$LINTER_VERSION" ]; then
+          spec="gha-workflow-linter==${LINTER_VERSION}"
+          echo "Pinning gha-workflow-linter to version: ${LINTER_VERSION}"
+        else
+          spec="gha-workflow-linter"
+          echo "Using latest released gha-workflow-linter from PyPI"
+        fi
+        echo "uvx_from=${spec}" >> "$GITHUB_OUTPUT"
 
     # ------------------------------------------------------------------
     # Pull request: gather changed workflow/action YAML files via
@@ -143,8 +166,8 @@ runs:
         done < matched.txt
 
         echo "Running gha-workflow-linter on changed files only"
-        uvx --from gha-workflow-linter gha-workflow-linter lint \
-          "${args[@]}"
+        uvx --from "${{ steps.resolve_version.outputs.uvx_from }}" \
+          gha-workflow-linter lint "${args[@]}"
 
     # ------------------------------------------------------------------
     # Full scan: workflow_dispatch, push, schedule, full_scan=true, etc.
@@ -159,6 +182,7 @@ runs:
         # Run gha-workflow-linter against the full path_prefix
         # (no auto-fix: see note in PR-changed-files step above)
         echo "Running gha-workflow-linter against: ${{ inputs.path_prefix }}"
-        uvx --from gha-workflow-linter gha-workflow-linter lint \
+        uvx --from "${{ steps.resolve_version.outputs.uvx_from }}" \
+          gha-workflow-linter lint \
           --no-auto-fix \
           "${{ inputs.path_prefix }}"


### PR DESCRIPTION
## Summary

Replaces the action's legacy implementation (a combination of
`tj-actions/changed-files` and
`zgosalvez/github-actions-ensure-sha-pinned-actions`) with the
[`gha-workflow-linter`](https://github.com/lfreleng-actions/gha-workflow-linter)
Python CLI, run via `uvx`.

`gha-workflow-linter` is the dedicated, more comprehensive replacement
for those legacy tools maintained alongside this action. It performs
SHA pinning enforcement, repository/reference existence validation,
caching and (optionally) auto-fix in a single tool.

## Commits

This PR is split into two atomic commits:

1. **Chore: Sync linting/pre-commit config from `actions-template`**
   Forklifts `.pre-commit-config.yaml` and `.editorconfig` from the
   `actions-template` repo so this repo matches the canonical baseline
   (adds `gha-workflow-linter`, `basedpyright`, `check-jsonschema`
   hooks; bumps `ruff`; fixes `max_line_legth` typo; adds
   `Signed-off-by` to pre-commit-ci autofix/autoupdate messages;
   skips `gha-workflow-linter` in pre-commit.ci sandbox since it
   needs network access).

2. **Feat: Replace legacy SHA-pin checks with gha-workflow-linter**
   - Use `astral-sh/setup-uv` to install `uv`.
   - Invoke the linter via
     `uvx --from gha-workflow-linter gha-workflow-linter lint`.
   - Pass `GITHUB_TOKEN` through to authenticate GraphQL API calls.
   - Add `timeout-minutes` to the testing workflow to satisfy the
     new `check-jsonschema` timeout policy introduced via the
     pre-commit baseline sync.
   - Refresh `README.md` to describe the new behaviour and
     dependencies.

## Default behaviour

- **`pull_request` events (default):** the action delegates to
  `lfreleng-actions/repository-metadata-action` to obtain the list of
  files changed by the PR, filters that list to YAML files under
  `<path_prefix>/.github/`, and runs `gha-workflow-linter` only on
  those files. If no workflow/action YAML changes, the linter (and
  `uv` install) are skipped entirely.
- **All other events (push, schedule, workflow_dispatch, ...) or
  `full_scan: 'true'` on PRs:** `gha-workflow-linter` walks the full
  workflow tree under `path_prefix`. The linter performs richer
  validation (SHA pinning, repo/ref existence, etc.) than the
  previous diff-only scan, so repositories that already SHA-pin
  throughout see no change; repositories that do not should run
  `gha-workflow-linter lint --auto-fix` locally once to migrate.

Callers can opt PR runs into the full-tree scan by passing
`full_scan: 'true'`.