### PR TITLE
Fix: prevent set -e from triggering when grep finds no unmodified files

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -82,12 +82,13 @@ runs:
           echo 'No changes in scope for check ⏩'
           echo 'workflow_changes=false' >> "$GITHUB_ENV"
         else
-          # Fixes bug where grep exits with error when all files changed
-          grep -Fvf changed.txt github.txt > unmodified.txt
-          status=$?
-          if [ $status -ne 0 ] && [ $status -ne 1 ]; then
+          # grep exits 1 when no unmodified files remain (all files changed);
+          # use || to capture status before set -e can trigger on exit code 1
+          status=0
+          grep -Fvf changed.txt github.txt > unmodified.txt || status=$?
+          if [ "$status" -ne 0 ] && [ "$status" -ne 1 ]; then
             echo "Error: grep failed with exit code $status" >&2
-            exit $status
+            exit "$status"
           fi
           while IFS= read -r yamlfile
           do


### PR DESCRIPTION
## Summary

When all `.github` yaml files are changed in a PR (e.g. a bulk dependency/hardening update), `grep -Fvf` exits with code **1** (no matches found). Under GitHub Actions' default shell (`bash -eo pipefail`), `set -e` aborts the script immediately — *before* `status=$?` can capture the exit code — so the existing workaround for the known grep-exits-1 case never fires.

## Root cause

```bash
# Current (broken) code
grep -Fvf changed.txt github.txt > unmodified.txt
status=$?   # never reached when grep exits 1 under set -e
if [ $status -ne 0 ] && [ $status -ne 1 ]; then ...
```

## Fix

Initialise `status=0` and use `|| status=$?` so the assignment always runs and the overall expression always exits 0:

```bash
status=0
grep -Fvf changed.txt github.txt > unmodified.txt || status=$?
if [ "$status" -ne 0 ] && [ "$status" -ne 1 ]; then ...
```

- `grep` exits 0 → `status` stays 0, continues normally
- `grep` exits 1 (no unmodified files) → `status=1`, `if` is false, continues normally
- `grep` exits 2+ (real error) → `status=2+`, `if` is true, exits with error

## Fixes

https://github.com/lfit/releng-reusable-workflows/issues/632