### PR TITLE
Fix: mitigate script injection via env: indirection for path_prefix

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -57,11 +57,13 @@ runs:
     - name: 'Check path_prefix directory'
       if: inputs.path_prefix != '.'
       shell: bash
+      env:
+        INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
       run: |
         # Validate path_prefix
-        if [ ! -d "${{ inputs.path_prefix }}" ]; then
+        if [ ! -d "$INPUT_PATH_PREFIX" ]; then
           echo 'Error: path_prefix is not a valid directory ❌'
-          echo "${{ inputs.path_prefix }}"
+          echo "$INPUT_PATH_PREFIX"
           exit 1
         fi
 
@@ -204,6 +206,8 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        MATCHED_FILE: ${{ steps.filter.outputs.matched_file }}
+        UVX_FROM: ${{ steps.resolve_version.outputs.uvx_from }}
       run: |
         # Lint only the changed workflow/action files (no auto-fix in CI:
         # rewrites in ephemeral runners are pointless and would mask errors)
@@ -211,10 +215,10 @@ runs:
         while IFS= read -r f; do
           [ -z "$f" ] && continue
           args+=(--files "$f")
-        done < "${{ steps.filter.outputs.matched_file }}"
+        done < "$MATCHED_FILE"
 
         echo "Running gha-workflow-linter on changed files only"
-        uvx --from "${{ steps.resolve_version.outputs.uvx_from }}" \
+        uvx --from "$UVX_FROM" \
           gha-workflow-linter lint "${args[@]}"
 
     # ------------------------------------------------------------------
@@ -226,11 +230,14 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
+        UVX_FROM: ${{ steps.resolve_version.outputs.uvx_from }}
       run: |
         # Run gha-workflow-linter against the full path_prefix
         # (no auto-fix: see note in PR-changed-files step above)
-        echo "Running gha-workflow-linter against: ${{ inputs.path_prefix }}"
-        uvx --from "${{ steps.resolve_version.outputs.uvx_from }}" \
+        echo "Running gha-workflow-linter against: $INPUT_PATH_PREFIX"
+        uvx --from "$UVX_FROM" \
           gha-workflow-linter lint \
           --no-auto-fix \
-          "${{ inputs.path_prefix }}"
+          -- \
+          "$INPUT_PATH_PREFIX"


### PR DESCRIPTION
Security Finding: #22 (MEDIUM)

Vulnerability Details:
- Finding #22 (MEDIUM, lines 62, 232): inputs.path_prefix was template-
  substituted directly into shell code in two locations:
  1. The safety check itself (line 62):
       if [ ! -d "${{ inputs.path_prefix }}" ]; then
     A value containing '$(id)' executes during the directory check
     — the validation meant to protect against bad paths is itself
     the injection point.
  2. The linter invocation (line 232):
       gha-workflow-linter lint ... "${{ inputs.path_prefix }}"
     Same class of injection.

  Positive note: inputs.linter_version was ALREADY correctly handled
  via env: indirection with regex validation — this is the reference
  pattern applied here.

Additional hardening:
- The 'Run gha-workflow-linter (pull request changed files)' step also
  had step outputs (${{ steps.*.outputs.* }}) template-substituted
  into shell. While step outputs are less attacker-controllable than
  action inputs, they are still subject to the same injection if a
  prior step's output is crafted. Moved to env: for consistency.

Remediation Applied:
- path_prefix in the 'Check path_prefix directory' step and the
  'Run gha-workflow-linter (full scan)' step now pass through env:.
- Step output references (matched_file, uvx_from) moved to env: block.

Impact:
- No behavioral change for legitimate callers.

Reference: lfreleng-actions composite action security audit (2025-06)

Signed-off-by: Anil Belur <askb23@gmail.com>
Signed-off-by: Anil Belur <abelur@linuxfoundation.org>
